### PR TITLE
Fix view holder binding permission

### DIFF
--- a/soleadapter/src/main/java/com/nikb7/soleadapter/RecyclerViewHolder.kt
+++ b/soleadapter/src/main/java/com/nikb7/soleadapter/RecyclerViewHolder.kt
@@ -5,7 +5,7 @@ import androidx.recyclerview.widget.RecyclerView
 import android.view.View
 import com.nikb7.soleadapter.BR
 
-open class RecyclerViewHolder(private val binding: ViewDataBinding) : androidx.recyclerview.widget.RecyclerView.ViewHolder(binding.root) {
+open class RecyclerViewHolder(val binding: ViewDataBinding) : androidx.recyclerview.widget.RecyclerView.ViewHolder(binding.root) {
 
     /**NOTE use only obj, lis as variable names inside xml files
      * obj: it is the class linked to the view


### PR DESCRIPTION
Since kotlin-android-extensions have been deprecated this is req to use view/data bindings in nested adapter use cases